### PR TITLE
enabled the use of multiple passport strategies

### DIFF
--- a/src/authenticator/passport.ts
+++ b/src/authenticator/passport.ts
@@ -3,7 +3,6 @@ import * as express from 'express';
 import * as _ from 'lodash';
 import * as passport from 'passport';
 import { ServiceAuthenticator } from '../server/model/server-types';
-import { Strategy } from 'passport-strategy';
 
 export interface PassportAuthenticatorOptions {
     authOptions?: passport.AuthenticateOptions;
@@ -13,7 +12,7 @@ export interface PassportAuthenticatorOptions {
 }
 
 export interface PassportAuthenticatorStrategy {
-    strategy: Strategy;
+    strategy: passport.Strategy;
     name: string;
 }
 
@@ -23,12 +22,12 @@ export class PassportAuthenticator implements ServiceAuthenticator {
 
     constructor(strategies: Array<PassportAuthenticatorStrategy>, options: PassportAuthenticatorOptions = {}) {
         this.options = options;
-        var strategyNames: Array<string> = [];
 
         strategies.forEach(strategy => {
-            strategyNames.push(strategy.name)
             passport.use(strategy.name, strategy.strategy);
         });
+
+        const strategyNames = strategies.map(x => x.name)
 
         this.authenticator = passport.authenticate(strategyNames, options.authOptions || {});
     }

--- a/src/authenticator/passport.ts
+++ b/src/authenticator/passport.ts
@@ -27,7 +27,7 @@ export class PassportAuthenticator implements ServiceAuthenticator {
             passport.use(strategy.name, strategy.strategy);
         });
 
-        const strategyNames = strategies.map(x => x.name)
+        const strategyNames = strategies.map(x => x.name);
 
         this.authenticator = passport.authenticate(strategyNames, options.authOptions || {});
     }

--- a/src/authenticator/passport.ts
+++ b/src/authenticator/passport.ts
@@ -27,7 +27,7 @@ export class PassportAuthenticator implements ServiceAuthenticator {
             passport.use(strategy.name, strategy.strategy);
         });
 
-        const strategyNames = strategies.map(x => x.name);
+        const strategyNames = strategies.map(x => x.name ? x.name : 'default');
 
         this.authenticator = passport.authenticate(strategyNames, options.authOptions || {});
     }

--- a/src/decorators/services.ts
+++ b/src/decorators/services.ts
@@ -74,11 +74,12 @@ export function Path(path: string) {
  * GET http://mydomain/people/123 (For all authorized users)
  * ```
  */
-export function Security(roles?: string | Array<string>, name?: string) {
+export function Security(roles?: string | Array<string>, names?: string | Array<string>) {
     roles = _.castArray(roles || '*');
+    names = _.castArray(names || 'default');
     return new ServiceDecorator('Security')
         .withProperty('roles', roles)
-        .withProperty('authenticator', name || 'default')
+        .withProperty('authenticators', names)
         .createDecorator();
 }
 

--- a/src/server/model/metadata.ts
+++ b/src/server/model/metadata.ts
@@ -17,7 +17,7 @@ export class ServiceClass {
     public targetClass: any;
     public path: string;
     public roles: Array<string>;
-    public authenticator: string;
+    public authenticators: Array<string>;
     public preProcessors: Array<ServiceProcessor>;
     public postProcessors: Array<ServiceProcessor>;
     public methods: Map<string, ServiceMethod>;
@@ -52,7 +52,7 @@ export class ServiceMethod {
     public name: string;
     public path: string;
     public roles: Array<string>;
-    public authenticator: string;
+    public authenticators: Array<string>;
     public resolvedPath: string;
     public httpMethod: HttpMethod;
     public parameters: Array<MethodParam> = new Array<MethodParam>();


### PR DESCRIPTION
Previous:

evari-node-api/ApiServer.ts
```
    const strategy = new jwtStrategy(
      {
        ...
      },
      () => {}
    )

    Server.registerAuthenticator(
      new PassportAuthenticator(strategy, {
        authOptions: {
          session: false,
          failWithError: true
        },
        rolesKey: 'cognito:groups'
      } as PassportAuthenticatorOptions)
    ) // implied default authenticator
```

widget-controller.ts
```
@Security() // same as @Security('*', 'default') but this is implied
```

New:

evari-node-api/ApiServer.ts
```
    const primaryStrategy = new jwtStrategy(
      {
        ...
      },
      () => {}
    )

    const secondaryStrategy = new jwtStrategy(
      {
        ...
      },
      () => {}
    )

    const options: PassportAuthenticatorOptions = {
      authOptions: {
        session: false,
        failWithError: true
      },
      rolesKey: 'cognito:groups'
    }

    // registers the middleware in passportjs (which is express under the hood)
    const passportjs = new PassportAuthenticator(
      [
        { strategy: primaryStrategy, name: 'default' },
        { strategy: secondaryStrategy, name: 'secondary' }
      ],
      options
    )

    // binds these security decorators to the passportjs middleware
    // default functionality for passport is that as long as it passes one of the 2 authenticators, it will succeed
    Server.registerAuthenticator(passportjs, 'default') // 'default' authenticator
    Server.registerAuthenticator(passportjs, 'secondary') // 'secondary' authenticator
```

widget-controller.ts
```
@Security('*', ['default', 'secondary'])
```